### PR TITLE
Alternative for space to cancel search

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -72,7 +72,7 @@ endif
 
 """ Extra commands
 " Press space to quit search:
-nnoremap <silent> <Space> :silent noh<Bar>echo<CR>
+nnoremap <silent> <Space> :noh<CR>
 " Save with W
 nnoremap W :w<CR>
 " `make` with E


### PR DESCRIPTION
On some machines, the old commands does not work. May be a vim vs nvim thing? This command works when the other does not.